### PR TITLE
fix: protocol version and tool schema in README and examples

### DIFF
--- a/assets/movieserver_config.json
+++ b/assets/movieserver_config.json
@@ -1,5 +1,5 @@
 {
-  "protocolVersion": "0.1.0",
+  "protocolVersion": "2025-03-26",
   "serverInfo": {
     "name": "DemoServer",
     "version": "0.1.0"

--- a/assets/movieserver_tools.json
+++ b/assets/movieserver_tools.json
@@ -3,12 +3,16 @@
     {
       "name": "get_movies",
       "description": "Get a list of movies currently playing in theaters",
-      "parameters": {}
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
     },
     {
       "name": "book_ticket",
       "description": "Book movie tickets for a specific showing",
-      "parameters": {
+      "inputSchema": {
         "type": "object",
         "properties": {
           "movieId": {
@@ -30,7 +34,7 @@
     {
       "name": "validate_age",
       "description": "Validate user age for movie rating",
-      "parameters": {
+      "inputSchema": {
         "type": "object",
         "properties": {
           "age": {

--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,7 @@ run_mcp_server "$@"
     {
       "name": "get_weather",
       "description": "Get current weather for a location",
-      "parameters": {
+      "inputSchema": {
         "type": "object",
         "properties": {
           "location": {
@@ -164,7 +164,7 @@ run_mcp_server "$@"
 
 ```json
 {
-  "protocolVersion": "0.1.0",
+  "protocolVersion": "2025-03-26",
   "serverInfo": {
     "name": "WeatherServer",
     "version": "1.0.0"


### PR DESCRIPTION
Thank you for creating this interesting tool. I tried to use it but found some small issues. I think we can fix them easily.

## Problem

I tried to use this tool and met protocol version errors.
Some MCP SDKs fail validation because of these issues:

- Protocol version is `0.1.0`
- Tool definitions use `parameters` instead of `inputSchema`

## Suggested Fix

We can make it work with the current MCP protocol with these small changes:

### 1. Update Protocol Version
```diff
- "protocolVersion": "0.1.0"
+ "protocolVersion": "2025-03-26"
```

### 2. Fix Tool Schema
```diff
{
  "name": "get_weather",
  "description": "Get current weather for a location",
-  "parameters": {
+  "inputSchema": {
    "type": "object",
    "properties": {
      "location": {
        "type": "string",
        "description": "City name or coordinates"
      }
    },
    "required": ["location"]
  }
}
```

## Test

The tests have not been working recently, it seems the asset file paths are moved in 7c12bab6.

I tested tested this change with my hand and it works with [typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk) & GitHub Copilot Chat (like you showed in your blog)